### PR TITLE
sercon: don't clear screen and don't disable line wrapping

### DIFF
--- a/src/sercon.c
+++ b/src/sercon.c
@@ -346,10 +346,12 @@ static void sercon_1000(struct bregs *regs)
     SET_LOW(sercon_row_last, 0);
     SET_LOW(sercon_attr_last, 0);
 
+#if 0
     sercon_term_reset();
     sercon_term_no_linewrap();
     if (clearscreen)
         sercon_term_clear_screen();
+#endif
 }
 
 /* Set text-mode cursor shape */


### PR DESCRIPTION
This helps with looking at emulator outputs (from both running locally and sanitycheck) as clearing screen and disabling line wrapping affect developer terminal.